### PR TITLE
fix: actually mount the log volume for persistent logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           cargo build --release
           cp test_data/* silo_input
           make
+          mkdir logs
           LAPIS_PORT=80 docker compose up --detach --wait
           curl localhost:80/sample/info
           docker compose down

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 sorted.ndjson.zst
 silo_output/*
 silo_input/*
+logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,8 @@ services:
         source: ./silo_output
         target: /data
         read_only: true
+      - type: bind
+        source: logs
+        target: /app/logs
+        read_only: false
     stop_grace_period: 0s


### PR DESCRIPTION
SILO was not running anymore. I do not know whether it was due to a server restart / memory contention as the logs from the docker container were not mounted to any file on the host.