### PR TITLE
Removing Nextclade reference / Simplify Metadata

### DIFF
--- a/database_config.yaml
+++ b/database_config.yaml
@@ -32,8 +32,6 @@ schema:
     - name: primer_protocol_name
       type: string
       generateIndex: true
-    - name: nextclade_reference
-      type: string
       generateIndex: true
     - name: read_id
       type: string

--- a/database_config.yaml
+++ b/database_config.yaml
@@ -6,20 +6,11 @@ schema:
     - name: batch_id
       type: string
       generateIndex: true
-    - name: sequencing_well_position
-      type: string
-      generateIndex: true
     - name: location_code
       type: string
       generateIndex: true
     - name: sampling_date
       type: date
-    - name: sequencing_date
-      type: string
-      generateIndex: true
-    - name: flow_cell_serial_number
-      type: string
-      generateIndex: true
     - name: read_length
       type: string 
       generateIndex: true
@@ -27,9 +18,6 @@ schema:
       type: string
       generateIndex: true
     - name: location_name
-      type: string
-      generateIndex: true
-    - name: primer_protocol_name
       type: string
       generateIndex: true
     - name: read_id

--- a/database_config.yaml
+++ b/database_config.yaml
@@ -32,7 +32,6 @@ schema:
     - name: primer_protocol_name
       type: string
       generateIndex: true
-      generateIndex: true
     - name: read_id
       type: string
     - name: sr2silo_version


### PR DESCRIPTION
Adjusting the database config for the next version of `sr2silo` i.e. `1.1.0`.

The new version will no longer have a hardcoded nucleotide and amino acid reference but instead fetch it from the running Lapis instance, to have one source of truth. 

This also means that the convoluted way of having `nextclade_ref` as the unique designator of the reference is gone. The Lapis instance files are submitted to define the reference – no need to include the reference in the metadata.

Further in PR279, we radically simplified the metadata, pruning all unnecessary fields. (after realising that V-Pipe uses only the `timeline.yaml` file as the source of truth)

Merge after: `sr2silo 1.1.0`

See PR for changes:
- https://github.com/cbg-ethz/sr2silo/pull/273
- https://github.com/cbg-ethz/sr2silo/pull/279