### PR TITLE
Update LAPIS config for 0.5.16 with silo client thread count

### DIFF
--- a/database_config.yaml
+++ b/database_config.yaml
@@ -29,3 +29,4 @@ schema:
   instanceName: wise-sarsCoV2
   features: []
   primaryKey: read_id
+siloClientThreadCount: 96


### PR DESCRIPTION
Merge after updating LAPIS to 0.5.16: https://github.com/GenSpectrum/LAPIS/pull/1352