### PR TITLE
feat: loculus filters

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -18,10 +18,8 @@ ansible/
 │       └── main.yml              # Host-specific configuration
 ├── templates/
 │   └── values.yaml.j2            # Jinja2 template for Kubernetes values
-├── playbooks/
-│   └── deploy.yml                # Deployment playbook
-└── secrets/                      # Legacy directory (can be removed)
-    └── my-values.yaml            # Original monolithic config
+└── playbooks/
+    └── deploy.yml                # Deployment playbook
 ```
 
 ## Usage

--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -69,6 +69,7 @@ organisms:
           type: string
           header: Sample details
           displayName: Sample ID
+          initiallyVisible: true
         - name: batchId
           type: string
           definition: "Sequencing batch"
@@ -84,10 +85,12 @@ organisms:
           autocomplete: true
           header: Sample details
           displayName: Location
+          initiallyVisible: true
         - name: samplingDate
           type: date
           header: Sample details
           displayName: Sampling Date
+          initiallyVisible: true
         - name: sr2siloVersion
           type: string
           header: srSILO info

--- a/ansible/templates/values.yaml.j2
+++ b/ansible/templates/values.yaml.j2
@@ -105,6 +105,9 @@ organisms:
 {% if metadata_item.autocomplete is defined %}
           autocomplete: {{ metadata_item.autocomplete | lower }}
 {% endif %}
+{% if metadata_item.initiallyVisible is defined %}
+          initiallyVisible: {{ metadata_item.initiallyVisible | lower }}
+{% endif %}
 {% endfor %}
       website:
         tableColumns:


### PR DESCRIPTION
Resolves
#64 

This pull request introduces improvements to the metadata configuration for organisms in the Ansible deployment, focusing on the visibility of specific metadata fields. Additionally, minor documentation cleanup was performed in the `ansible/README.md`.

**Metadata visibility enhancements:**

* Added the `initiallyVisible: true` property to key metadata fields (`sampleId`, `location`, and `samplingDate`) in `ansible/group_vars/all/main.yml`, ensuring these fields are shown by default in the UI. [[1]](diffhunk://#diff-3b0c07d0827b288ff1e93680a2f66f962ced8085030bd9cd7a0e1023c44c2297R72) [[2]](diffhunk://#diff-3b0c07d0827b288ff1e93680a2f66f962ced8085030bd9cd7a0e1023c44c2297R88-R93)
* Updated the Jinja2 template in `ansible/templates/values.yaml.j2` to render the `initiallyVisible` property for metadata items when defined.

**Documentation and structure cleanup:**

* Cleaned up the directory listing in `ansible/README.md` by removing the legacy `secrets/` directory and fixing indentation for `playbooks/`.