### PR TITLE
chore(srSilo): test preview docker image of SILO `Sparse Positions` and update LAPIS to 0.6.1

### DIFF
--- a/roles/srsilo/templates/docker-compose-preprocessing.yml.j2
+++ b/roles/srsilo/templates/docker-compose-preprocessing.yml.j2
@@ -1,6 +1,6 @@
 services:
   siloPreprocessing:
-    image: ghcr.io/genspectrum/lapis-silo:0.8.5
+    image: ghcr.io/genspectrum/lapis-silo:pr-1072
     command: preprocessing
     mem_limit: {{ srsilo_docker_memory_limit }}
     volumes:

--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -1,6 +1,6 @@
 services:
   lapisOpen:
-    image: ghcr.io/genspectrum/lapis:0.5.17
+    image: ghcr.io/genspectrum/lapis:0.6.2
     restart: unless-stopped
     ports:
       - ${LAPIS_PORT}:8080
@@ -20,7 +20,7 @@ services:
     stop_grace_period: 0s
 
   silo:
-    image: ghcr.io/genspectrum/lapis-silo:0.8.5
+    image: ghcr.io/genspectrum/lapis-silo:pr-1072
     mem_limit: {{ srsilo_docker_memory_limit }}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
We will already test the following SILO PR https://github.com/GenSpectrum/LAPIS-SILO/pull/993

This should not be merged in the current state, but we should wait until the SILO PR is merged and a new SILO version has been created.