### PR TITLE
feat(silo): add a memory limit for the SILO api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   silo:
     image: ghcr.io/genspectrum/lapis-silo:0.8.5
+    mem_limit: 350g
     restart: unless-stopped
     ports:
       - 8081:8081


### PR DESCRIPTION
SILO can load new data-sets while running. This will require SILO to keep two datasets in memory at the same time. To prevent this, this PR sets a memory limit to the running SILO docker container. (previously only the preprocessing had a memory limit)

This can prevent the following problem:

SILO is running with a 300GB dataset. 

Another preprocessing run finishes and produces another 300GB dataset
-> SILO tries to load the second dataset automatically tries to go up to 600GB of memory, which can lead to OOM problems