### PR TITLE
Fix: Preserve check_new_data exit code in pipeline

### DIFF
--- a/roles/srsilo/tasks/check_new_data.yml
+++ b/roles/srsilo/tasks/check_new_data.yml
@@ -20,14 +20,17 @@
 
 - name: Check for new data using check_new_data binary
   shell: |
+    set -o pipefail
     {{ srsilo_tools_path }}/target/release/check_new_data \
       --api-base-url "{{ srsilo_api_base_url }}" \
       --timestamp-file "{{ srsilo_base_path }}/.last_update" \
       --days-back {{ srsilo_fetch_days }} \
       --output-timestamp-file "{{ srsilo_base_path }}/.next_timestamp" \
-      2>&1 | systemd-cat -t srsilo-check-data -p info
+      2>&1 | tee >(systemd-cat -t srsilo-check-data -p info)
+    exit ${PIPESTATUS[0]}
   args:
     chdir: "{{ srsilo_base_path }}"
+    executable: /bin/bash
   register: check_new_data_result
   failed_when: check_new_data_result.rc == 2  # Only fail on error (rc=2)
   changed_when: check_new_data_result.rc == 0  # Changed when new data found (rc=0)


### PR DESCRIPTION
The pipeline was incorrectly continuing when no new data was found. Piping to systemd-cat always returns exit code 0, swallowing the actual exit code from check_new_data binary.

Changes:
- Use 'tee >(systemd-cat)' to preserve exit code while logging
- Add 'set -o pipefail' and 'exit ${PIPESTATUS[0]}' to capture original exit code
- Switch to bash executable for PIPESTATUS support

Now correctly:
- Exit 0 (new data) → pipeline continues
- Exit 1 (no data) → pipeline stops
- Exit 2 (error) → task fails