### PR TITLE
Removing Banner Message for Beta Notice

### DIFF
--- a/group_vars/loculus/main.yml
+++ b/group_vars/loculus/main.yml
@@ -6,7 +6,7 @@ logo:
   width: 200
   height: 180
 
-bannerMessage: 'This is a beta version of W-ASAP. Expect occasional modifications to the datastore structure and content.'
+bannerMessage: ''
 
 loculus_environment: 'local' # Do not change this: this setup uses a "local" environment as the public traffic is proxied through nginx.
 


### PR DESCRIPTION
With the launch of W-ASAP v1 on GenSpectrum, we're removing the beta notice and aiming for continuous uptime from here on:

<img width="1118" height="613" alt="Screenshot 2025-11-18 at 12 08 36" src="https://github.com/user-attachments/assets/ce4027b3-a9c9-4952-b87c-ac4209b8c49f" />
