### PR TITLE
chore(sr2silo): tune for larger lapis cache

### DIFF
--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -4,6 +4,9 @@ services:
     restart: unless-stopped
     ports:
       - ${LAPIS_PORT}:8080
+    environment:
+      # Cache size tuned to avoid GC pressure, more predictable maximum cache size (see #147) 
+      - SPRING_CACHE_CAFFEINE_SPEC=maximumSize=50000
     command: --silo.url=http://silo:8081
     volumes:
       - type: bind


### PR DESCRIPTION
Addresses #147 

* Covid Wastewater instance observes garbage collector activity
* softValues are assumed to be the source of GC activity
* manually configure cache size to avoid this