### PR TITLE
chore(srsilo): increase lapis cache

### DIFF
--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -6,7 +6,7 @@ services:
       - ${LAPIS_PORT}:8080
     environment:
       # Cache size tuned to avoid GC pressure, more predictable maximum cache size (see #147) 
-      - SPRING_CACHE_CAFFEINE_SPEC=maximumSize=50000
+      - SPRING_CACHE_CAFFEINE_SPEC=maximumSize=500000
     command: --silo.url=http://silo:8081
     volumes:
       - type: bind


### PR DESCRIPTION
Some queries fail upon our changes in softValues #153, this is probably due to a too small cache, now enforced by the maxmimumSize.

* Manual Search leads to 2x9k requests currenty
* for 6 locations
* we 10x the cache from 50k to 500k
* we are not limited in memory on this machine