### PR TITLE
feat(srsilo): Update all task files to use virus-specific variables 

### DIFF
--- a/roles/srsilo/tasks/check_new_data.yml
+++ b/roles/srsilo/tasks/check_new_data.yml
@@ -5,7 +5,7 @@
 
 - name: Ensure timestamp file location exists
   file:
-    path: "{{ srsilo_base_path }}"
+    path: "{{ srsilo_virus_path }}"
     state: directory
     owner: "{{ srsilo_user }}"
     group: "{{ srsilo_group }}"
@@ -13,7 +13,7 @@
   become: yes
 
 - name: Log phase start to journal
-  shell: 'echo "PHASE 2: Check new data - START" | systemd-cat -t srsilo-phase2 -p info'
+  shell: 'echo "PHASE 2: Check new data for {{ srsilo_virus }} - START" | systemd-cat -t srsilo-phase2 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false
@@ -22,14 +22,15 @@
   shell: |
     set -o pipefail
     {{ srsilo_tools_path }}/target/release/check_new_data \
+      --organism {{ srsilo_current_organism }} \
       --api-base-url "{{ srsilo_api_base_url }}" \
-      --timestamp-file "{{ srsilo_base_path }}/.last_update" \
+      --timestamp-file "{{ srsilo_virus_last_update }}" \
       --days-back {{ srsilo_fetch_days }} \
-      --output-timestamp-file "{{ srsilo_base_path }}/.next_timestamp" \
+      --output-timestamp-file "{{ srsilo_virus_next_timestamp }}" \
       2>&1 | tee >(systemd-cat -t srsilo-check-data -p info)
     exit ${PIPESTATUS[0]}
   args:
-    chdir: "{{ srsilo_base_path }}"
+    chdir: "{{ srsilo_virus_path }}"
     executable: /bin/bash
   register: check_new_data_result
   failed_when: check_new_data_result.rc == 2  # Only fail on error (rc=2)
@@ -38,7 +39,7 @@
   become_user: "{{ srsilo_user }}"
 
 - name: Log phase result to journal
-  shell: 'echo "PHASE 2: Check new data - {{ "NEW DATA FOUND" if check_new_data_result.rc == 0 else "NO NEW DATA" if check_new_data_result.rc == 1 else "ERROR" }}" | systemd-cat -t srsilo-phase2 -p {{ "info" if check_new_data_result.rc != 2 else "err" }}'
+  shell: 'echo "PHASE 2: Check new data for {{ srsilo_virus }} - {{ "NEW DATA FOUND" if check_new_data_result.rc == 0 else "NO NEW DATA" if check_new_data_result.rc == 1 else "ERROR" }}" | systemd-cat -t srsilo-phase2 -p {{ "info" if check_new_data_result.rc != 2 else "err" }}'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false

--- a/roles/srsilo/tasks/cleanup_indexes.yml
+++ b/roles/srsilo/tasks/cleanup_indexes.yml
@@ -4,7 +4,7 @@
 # Retention policy: Keep N newest indexes, delete those older than M days
 
 - name: Log phase start to journal
-  shell: 'echo "PHASE 3: Cleanup old indexes - START" | systemd-cat -t srsilo-phase3 -p info'
+  shell: 'echo "PHASE 3: Cleanup old indexes for {{ srsilo_virus }} - START" | systemd-cat -t srsilo-phase3 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false
@@ -13,13 +13,13 @@
   debug:
     msg:
       - "=== Cleanup Old Indexes ==="
-      - "Output directory: {{ srsilo_data_output }}"
+      - "Output directory: {{ srsilo_virus_output }}"
       - "Retention days: {{ srsilo_retention_days }}"
       - "Min keep: {{ srsilo_retention_min_keep }}"
 
 - name: Find all index directories
   find:
-    path: "{{ srsilo_data_output }}"
+    path: "{{ srsilo_virus_output }}"
     file_type: directory
     recurse: no
   register: all_indexes
@@ -30,7 +30,7 @@
 
 - name: Find indexes older than retention period
   find:
-    path: "{{ srsilo_data_output }}"
+    path: "{{ srsilo_virus_output }}"
     file_type: directory
     age: "{{ srsilo_retention_days }}d"
     recurse: no
@@ -84,7 +84,7 @@
   when: indexes_to_delete is not defined or indexes_to_delete | length == 0
 
 - name: Log phase complete to journal
-  shell: 'echo "PHASE 3: Cleanup - COMPLETE (deleted {{ deletion_result.results | default([]) | length }} indexes)" | systemd-cat -t srsilo-phase3 -p info'
+  shell: 'echo "PHASE 3: Cleanup for {{ srsilo_virus }} - COMPLETE (deleted {{ deletion_result.results | default([]) | length }} indexes)" | systemd-cat -t srsilo-phase3 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false

--- a/roles/srsilo/tasks/fetch_data.yml
+++ b/roles/srsilo/tasks/fetch_data.yml
@@ -5,7 +5,7 @@
 
 - name: Ensure input directory exists
   file:
-    path: "{{ srsilo_data_input }}"
+    path: "{{ srsilo_virus_input }}"
     state: directory
     owner: "{{ srsilo_user }}"
     group: "{{ srsilo_group }}"
@@ -23,15 +23,15 @@
 - name: Display fetch configuration
   debug:
     msg:
-      - "=== Fetching data from LAPIS API ==="
+      - "=== Fetching data for {{ srsilo_virus }} from LAPIS API ==="
       - "API: {{ srsilo_api_base_url }}"
       - "Start date: {{ fetch_start_date }}"
       - "Days: {{ srsilo_fetch_days }}"
       - "Max reads per batch: {{ srsilo_fetch_max_reads }}"
-      - "Output directory: {{ srsilo_data_input }}"
+      - "Output directory: {{ srsilo_virus_input }}"
 
 - name: Log phase start to journal
-  shell: 'echo "PHASE 4: Fetch data from API - START" | systemd-cat -t srsilo-phase4 -p info'
+  shell: 'echo "PHASE 4: Fetch data for {{ srsilo_virus }} - START" | systemd-cat -t srsilo-phase4 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false
@@ -39,14 +39,15 @@
 - name: Fetch data from LAPIS API
   shell: |
     {{ srsilo_tools_path }}/target/release/fetch_silo_data \
+      --organism {{ srsilo_current_organism }} \
       --start-date "{{ fetch_start_date }}" \
       --days {{ srsilo_fetch_days }} \
       --max-reads {{ srsilo_fetch_max_reads }} \
-      --output-dir "{{ srsilo_data_input }}" \
+      --output-dir "{{ srsilo_virus_input }}" \
       --api-base-url "{{ srsilo_api_base_url }}" \
       2>&1 | systemd-cat -t srsilo-fetch -p info
   args:
-    chdir: "{{ srsilo_base_path }}"
+    chdir: "{{ srsilo_virus_path }}"
   become: yes
   become_user: "{{ srsilo_user }}"
   register: fetch_result
@@ -62,13 +63,13 @@
 
 - name: Verify downloaded files exist
   find:
-    path: "{{ srsilo_data_input }}"
+    path: "{{ srsilo_virus_input }}"
     patterns: "*.ndjson.zst"
     file_type: file
   register: fetched_files
 
 - name: Log phase complete to journal
-  shell: 'echo "PHASE 4: Fetch data - COMPLETE ({{ fetched_files.matched }} files)" | systemd-cat -t srsilo-phase4 -p info'
+  shell: 'echo "PHASE 4: Fetch data for {{ srsilo_virus }} - COMPLETE ({{ fetched_files.matched }} files)" | systemd-cat -t srsilo-phase4 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false

--- a/roles/srsilo/tasks/finalize_processing.yml
+++ b/roles/srsilo/tasks/finalize_processing.yml
@@ -20,9 +20,9 @@
   debug:
     msg:
       - "=== Finalizing Processing ==="
-      - "Output directory: {{ srsilo_data_output }}"
-      - "Marker: {{ srsilo_data_output }}/.preprocessing_in_progress"
-      - "Timestamp: {{ srsilo_base_path }}/.last_update"
+      - "Output directory: {{ srsilo_virus_output }}"
+      - "Marker: {{ srsilo_virus_output }}/.preprocessing_in_progress"
+      - "Timestamp: {{ srsilo_virus_last_update }}"
   tags: [finalize]
 
 - name: Check if Docker is available
@@ -38,7 +38,7 @@
 
 - name: Find all index directories
   find:
-    paths: "{{ srsilo_data_output }}"
+    paths: "{{ srsilo_virus_output }}"
     file_type: directory
     recurse: no
   register: all_indexes
@@ -68,7 +68,7 @@
   block:
     - name: Read preprocessing marker
       slurp:
-        path: "{{ srsilo_data_output }}/.preprocessing_in_progress"
+        path: "{{ srsilo_virus_output }}/.preprocessing_in_progress"
       become: yes
       become_user: "{{ srsilo_user }}"
       register: marker_content
@@ -83,18 +83,18 @@
 
     - name: Delete failed/partial index
       file:
-        path: "{{ srsilo_data_output }}/{{ failed_index_ts }}"
+        path: "{{ srsilo_virus_output }}/{{ failed_index_ts }}"
         state: absent
       become: yes
       become_user: "{{ srsilo_user }}"
-      when: 
+      when:
         - marker_content is succeeded
         - failed_index_ts is defined
       tags: [finalize, failure, rollback]
 
     - name: Remove preprocessing marker after failure
       file:
-        path: "{{ srsilo_data_output }}/.preprocessing_in_progress"
+        path: "{{ srsilo_virus_output }}/.preprocessing_in_progress"
         state: absent
       become: yes
       become_user: "{{ srsilo_user }}"
@@ -102,7 +102,7 @@
 
     - name: Cleanup next timestamp file on failure
       file:
-        path: "{{ srsilo_base_path }}/.next_timestamp"
+        path: "{{ srsilo_virus_next_timestamp }}"
         state: absent
       become: yes
       become_user: "{{ srsilo_user }}"
@@ -110,7 +110,7 @@
 
     - name: Find previous valid index for rollback
       find:
-        paths: "{{ srsilo_data_output }}"
+        paths: "{{ srsilo_virus_output }}"
         file_type: directory
         recurse: no
       register: remaining_indexes
@@ -176,7 +176,7 @@
     # --- Success Path: New index is valid ---
     - name: Remove preprocessing marker
       file:
-        path: "{{ srsilo_data_output }}/.preprocessing_in_progress"
+        path: "{{ srsilo_virus_output }}/.preprocessing_in_progress"
         state: absent
       become: yes
       become_user: "{{ srsilo_user }}"
@@ -187,7 +187,7 @@
         docker compose down --remove-orphans || true
         docker network prune -f || true
       args:
-        chdir: "{{ srsilo_tools_path }}"
+        chdir: "{{ srsilo_virus_config_path }}"
       when: docker_check.rc == 0
       tags: [finalize, success, docker]
 
@@ -205,26 +205,26 @@
 
     - name: Check if next timestamp file exists
       stat:
-        path: "{{ srsilo_base_path }}/.next_timestamp"
+        path: "{{ srsilo_virus_next_timestamp }}"
       register: next_timestamp_stat
       tags: [finalize, success]
 
     - name: Update timestamp file on success
       copy:
-        src: "{{ srsilo_base_path }}/.next_timestamp"
-        dest: "{{ srsilo_base_path }}/.last_update"
+        src: "{{ srsilo_virus_next_timestamp }}"
+        dest: "{{ srsilo_virus_last_update }}"
         remote_src: yes
         mode: '0644'
       become: yes
       become_user: "{{ srsilo_user }}"
-      when: 
+      when:
         - srsilo_newest_index is defined
         - next_timestamp_stat.stat.exists
       tags: [finalize, success]
 
     - name: Cleanup next timestamp file
       file:
-        path: "{{ srsilo_base_path }}/.next_timestamp"
+        path: "{{ srsilo_virus_next_timestamp }}"
         state: absent
       become: yes
       become_user: "{{ srsilo_user }}"

--- a/roles/srsilo/tasks/prerequisites.yml
+++ b/roles/srsilo/tasks/prerequisites.yml
@@ -45,7 +45,7 @@
     mode: '0755'
   become: yes
 
-- name: Ensure data directories exist
+- name: Ensure virus data directories exist
   file:
     path: "{{ item }}"
     state: directory
@@ -54,11 +54,10 @@
     mode: '0755'
   become: yes
   loop:
-    - "{{ srsilo_data_input }}"
-    - "{{ srsilo_data_output }}"
-    - "{{ srsilo_data_sorted_chunks }}"
-    - "{{ srsilo_data_tmp }}"
-    - "{{ srsilo_tools_path }}/logs"
+    - "{{ srsilo_virus_input }}"
+    - "{{ srsilo_virus_output }}"
+    - "{{ srsilo_virus_sorted_chunks }}"
+    - "{{ srsilo_virus_tmp }}"
 
 - name: Ensure Ansible log directory exists
   file:

--- a/roles/srsilo/tasks/silo_preprocessing.yml
+++ b/roles/srsilo/tasks/silo_preprocessing.yml
@@ -7,24 +7,24 @@
   debug:
     msg:
       - "=== SILO Preprocessing ==="
-      - "Input: {{ srsilo_base_path }}/sorted.ndjson.zst"
-      - "Output: {{ srsilo_data_output }}/<timestamp>/"
-      - "Tools: {{ srsilo_tools_path }}"
+      - "Input: {{ srsilo_virus_sorted_file }}"
+      - "Output: {{ srsilo_virus_output }}/<timestamp>/"
+      - "Config: {{ srsilo_virus_config_path }}"
 
 - name: Log phase start to journal
-  shell: 'echo "PHASE 6: SILO preprocessing - START" | systemd-cat -t srsilo-phase6 -p info'
+  shell: 'echo "PHASE 6: SILO preprocessing for {{ srsilo_virus }} - START" | systemd-cat -t srsilo-phase6 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false
 
 - name: Verify sorted file exists
   stat:
-    path: "{{ srsilo_base_path }}/sorted.ndjson.zst"
+    path: "{{ srsilo_virus_sorted_file }}"
   register: sorted_file_check
 
 - name: Fail if sorted file missing
   fail:
-    msg: "Sorted file not found: {{ srsilo_base_path }}/sorted.ndjson.zst"
+    msg: "Sorted file not found: {{ srsilo_virus_sorted_file }}"
   when: not sorted_file_check.stat.exists
 
 - name: Verify Docker is available
@@ -36,14 +36,14 @@
 - name: Clean up any previous preprocessing containers
   shell: docker compose -f docker-compose-preprocessing.yml down -v || true
   args:
-    chdir: "{{ srsilo_tools_path }}"
+    chdir: "{{ srsilo_virus_config_path }}"
   become: yes
   changed_when: false
 
 - name: Run preprocessing container
   shell: docker compose -f docker-compose-preprocessing.yml up --exit-code-from siloPreprocessing
   args:
-    chdir: "{{ srsilo_tools_path }}"
+    chdir: "{{ srsilo_virus_config_path }}"
   become: yes
   register: preprocessing_result
   failed_when: preprocessing_result.rc != 0
@@ -54,7 +54,7 @@
 
 - name: Find created index directory
   find:
-    path: "{{ srsilo_data_output }}"
+    path: "{{ srsilo_virus_output }}"
     file_type: directory
     recurse: no
   register: output_indexes
@@ -69,7 +69,7 @@
     index_name: "{{ new_index_dir.path | basename if new_index_dir is defined and new_index_dir.path is defined else 'unknown' }}"
 
 - name: Log phase complete to journal
-  shell: 'echo "PHASE 6: SILO preprocessing - COMPLETE (index: {{ index_name }})" | systemd-cat -t srsilo-phase6 -p info'
+  shell: 'echo "PHASE 6: SILO preprocessing for {{ srsilo_virus }} - COMPLETE (index: {{ index_name }})" | systemd-cat -t srsilo-phase6 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false

--- a/roles/srsilo/tasks/sort_and_merge.yml
+++ b/roles/srsilo/tasks/sort_and_merge.yml
@@ -7,19 +7,19 @@
   debug:
     msg:
       - "=== Sorting and Merging Reads ==="
-      - "Input: {{ srsilo_data_input }}"
-      - "Chunks: {{ srsilo_data_sorted_chunks }}"
-      - "Output: {{ srsilo_base_path }}/sorted.ndjson.zst"
+      - "Input: {{ srsilo_virus_input }}"
+      - "Chunks: {{ srsilo_virus_sorted_chunks }}"
+      - "Output: {{ srsilo_virus_sorted_file }}"
 
 - name: Log phase start to journal
-  shell: 'echo "PHASE 6: Sort and merge reads - START" | systemd-cat -t srsilo-phase6 -p info'
+  shell: 'echo "PHASE 6: Sort and merge for {{ srsilo_virus }} - START" | systemd-cat -t srsilo-phase6 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false
 
 - name: Find input files to process
   find:
-    path: "{{ srsilo_data_input }}"
+    path: "{{ srsilo_virus_input }}"
     patterns: "*.ndjson.zst"
     file_type: file
   register: input_files
@@ -28,26 +28,26 @@
   assert:
     that:
       - input_files.matched > 0
-    fail_msg: "No input files found in {{ srsilo_data_input }}"
+    fail_msg: "No input files found in {{ srsilo_virus_input }}"
     success_msg: "Found {{ input_files.matched }} input file(s) to process"
 
 - name: Split input files into sorted chunks
   shell: |
     (zstdcat "{{ item.path }}" | \
     {{ srsilo_tools_path }}/target/release/split_into_sorted_chunks \
-      --output-path "{{ srsilo_data_sorted_chunks }}/$(basename '{{ item.path }}')" \
+      --output-path "{{ srsilo_virus_sorted_chunks }}/$(basename '{{ item.path }}')" \
       --chunk-size {{ srsilo_chunk_size }} \
       --sort-field-path /main/offset) 2>&1 | systemd-cat -t srsilo-split -p info
-    ls {{ srsilo_data_sorted_chunks }}/$(basename '{{ item.path }}')/chunk_*.ndjson.zst >> {{ srsilo_data_sorted_chunks }}/chunks.list
+    ls {{ srsilo_virus_sorted_chunks }}/$(basename '{{ item.path }}')/chunk_*.ndjson.zst >> {{ srsilo_virus_sorted_chunks }}/chunks.list
   args:
-    chdir: "{{ srsilo_base_path }}"
+    chdir: "{{ srsilo_virus_path }}"
   loop: "{{ input_files.files }}"
   become: yes
   become_user: "{{ srsilo_user }}"
   register: split_result
 
 - name: Count created chunks
-  shell: wc -l < {{ srsilo_data_sorted_chunks }}/chunks.list || echo 0
+  shell: wc -l < {{ srsilo_virus_sorted_chunks }}/chunks.list || echo 0
   register: chunk_count
   changed_when: false
 
@@ -59,24 +59,24 @@
 
 - name: Merge sorted chunks
   shell: |
-    (cat {{ srsilo_data_sorted_chunks }}/chunks.list | \
+    (cat {{ srsilo_virus_sorted_chunks }}/chunks.list | \
     {{ srsilo_tools_path }}/target/release/merge_sorted_chunks \
-      --tmp-directory {{ srsilo_data_tmp }} \
+      --tmp-directory {{ srsilo_virus_tmp }} \
       --sort-field-path /main/offset | \
-    zstd > {{ srsilo_base_path }}/sorted.ndjson.zst) 2>&1 | systemd-cat -t srsilo-merge -p info
+    zstd > {{ srsilo_virus_sorted_file }}) 2>&1 | systemd-cat -t srsilo-merge -p info
   args:
-    chdir: "{{ srsilo_base_path }}"
+    chdir: "{{ srsilo_virus_path }}"
   become: yes
   become_user: "{{ srsilo_user }}"
   register: merge_result
 
 - name: Get sorted file size
   stat:
-    path: "{{ srsilo_base_path }}/sorted.ndjson.zst"
+    path: "{{ srsilo_virus_sorted_file }}"
   register: sorted_file
 
 - name: Log phase complete to journal
-  shell: 'echo "PHASE 6: Sort and merge - COMPLETE ({{ chunk_count.stdout | trim }} chunks, {{ (sorted_file.stat.size / 1024 / 1024) | round(2) }} MB)" | systemd-cat -t srsilo-phase6 -p info'
+  shell: 'echo "PHASE 6: Sort and merge for {{ srsilo_virus }} - COMPLETE ({{ chunk_count.stdout | trim }} chunks, {{ (sorted_file.stat.size / 1024 / 1024) | round(2) }} MB)" | systemd-cat -t srsilo-phase6 -p info'
   become: yes
   become_user: "{{ srsilo_user }}"
   changed_when: false


### PR DESCRIPTION
Updated 7 task files to use virus-specific path variables and add --organism parameter to Rust tools for multi-virus support.

Changes:
- check_new_data.yml: Added --organism parameter, updated paths to virus-specific
- cleanup_indexes.yml: Replaced srsilo_data_output with srsilo_virus_output
- fetch_data.yml: Added --organism parameter, updated all input paths
- sort_and_merge.yml: Updated all paths to virus-specific equivalents
- silo_preprocessing.yml: Updated to use srsilo_virus_config_path for docker-compose
- finalize_processing.yml: Updated all output and timestamp paths
- prerequisites.yml: Updated directory creation to use virus-specific paths

Variable Migration:
- srsilo_data_input → srsilo_virus_input
- srsilo_data_output → srsilo_virus_output
- srsilo_data_sorted_chunks → srsilo_virus_sorted_chunks
- srsilo_data_tmp → srsilo_virus_tmp
- {{ srsilo_base_path }}/.last_update → srsilo_virus_last_update
- {{ srsilo_base_path }}/.next_timestamp → srsilo_virus_next_timestamp
- {{ srsilo_base_path }}/sorted.ndjson.zst → srsilo_virus_sorted_file

Rust Tool Updates:
- check_new_data: Added --organism {{ srsilo_current_organism }}
- fetch_silo_data: Added --organism {{ srsilo_current_organism }}

Log Enhancements:
- Added virus context to phase logs (e.g., "PHASE 2: Check new data for {{ srsilo_virus }} - START")

Testing:
✓ Syntax validation passed
✓ No legacy path variables remain in task files
✓ --organism parameter added to both Rust tools

Dependencies: PR 2 (variables), PR 3 (configs), PR 4 (templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)