### PR TITLE
fix: clean entire input directory to prevent data accumulation

### DIFF
--- a/playbooks/srsilo/_tasks/run-single-virus-pipeline.yml
+++ b/playbooks/srsilo/_tasks/run-single-virus-pipeline.yml
@@ -148,31 +148,23 @@
       when: preprocessing_marker.stat.exists
   when: srsilo_has_new_data
 
-- name: "PHASE 3: Clean old downloaded data for {{ current_virus }}"
-  block:
-    - name: Find old input files
-      find:
-        path: "{{ srsilo_virus_input }}"
-        patterns: "*.ndjson.zst"
-        age: "1d"
-      register: old_input_files
-    
-    - name: Remove old input files
-      file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ old_input_files.files }}"
-      become: yes
-      when: old_input_files.matched > 0
-    
-    - name: Display input cleanup result
-      debug:
-        msg: "✓ Removed {{ old_input_files.matched }} old input file(s)"
-      when: old_input_files.matched > 0
-  when: srsilo_has_new_data
-
 - name: "PHASE 3: Reset working directories for {{ current_virus }}"
   block:
+    - name: Clean input directory (prevent accumulation from previous runs)
+      file:
+        path: "{{ srsilo_virus_input }}"
+        state: absent
+      become: yes
+
+    - name: Recreate input directory
+      file:
+        path: "{{ srsilo_virus_input }}"
+        state: directory
+        owner: "{{ srsilo_user }}"
+        group: "{{ srsilo_group }}"
+        mode: '0755'
+      become: yes
+
     - name: Clean sorted chunks directory
       file:
         path: "{{ srsilo_virus_sorted_chunks }}"


### PR DESCRIPTION
## Summary
- Replace `age: "1d"` file-by-file cleanup with full directory delete/recreate
- Prevents input files from accumulating across pipeline runs
- Consistent with how `sorted_chunks` and `tmp` directories are handled

Fixes #198

## Test plan
- [ ] Verify pipeline runs successfully after merge
- [ ] Confirm input directory is empty before fetch phase
- [ ] Confirm database sequence count matches fetch_max_reads limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)