### PR TITLE
docs(nginx): Update README to reflect proxy_pass routing approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Deploy Nginx as a reverse proxy with SSL termination for all services:
 ```bash
 ansible-playbook playbooks/setup_nginx.yml -i inventory.ini --ask-become-pass
 ```
-See [`docs/nginx/README.md`](docs/nginx/README.md) for details.
+See [`roles/nginx/README.md`](roles/nginx/README.md) for details.
 
 ## Configuration
 

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -18,13 +18,26 @@ LAPIS and SILO support multiple virus instances via path-based routing:
 The `/covid` and `/rsva` prefixes are stripped before proxying to backends. For example:
 - `https://lapis.wasap.genspectrum.org/covid/sample/info` → backend receives `/sample/info`
 
-This is achieved using nginx rewrite rules:
+This is achieved using nginx's `proxy_pass` with a trailing slash, which automatically strips the matched location prefix:
+
 ```nginx
-location /covid {
-    rewrite ^/covid(.*)$ $1 break;
-    proxy_pass http://127.0.0.1:8083;
+# Upstream definitions (in conf.d/wasap.conf)
+upstream lapis-covid {
+    server 127.0.0.1:8083;
+}
+
+# Location block (in sites-available/lapis.j2)
+location /covid/ {
+    proxy_pass http://lapis-covid/;  # trailing slash strips /covid/ prefix
+    proxy_set_header X-Forwarded-Prefix /covid/;
 }
 ```
+
+Key implementation details:
+- **Trailing slash in `proxy_pass`**: When both the location and proxy_pass end with `/`, nginx strips the location prefix from the request URI
+- **Upstream blocks**: Defined in `conf.d/wasap.conf.j2` for cleaner configuration and future load balancing support
+- **X-Forwarded-Prefix header**: Tells backends the original path prefix for proper URL generation in responses
+- **Trailing slash redirects**: Requests to `/covid` (without trailing slash) return 301 to `/covid/` for consistent behavior
 
 ### Backward Compatibility
 
@@ -102,11 +115,20 @@ To test that path stripping works correctly without SSL complications:
 ```bash
 # Create a test server on an unused port
 cat > /tmp/test.conf << 'EOF'
+upstream test-backend {
+    server 127.0.0.1:8083;
+}
+
 server {
     listen 9999;
-    location /covid {
-        rewrite ^/covid(.*)$ $1 break;
-        proxy_pass http://127.0.0.1:8083;
+
+    location = /covid {
+        return 301 /covid/;
+    }
+
+    location /covid/ {
+        proxy_pass http://test-backend/;
+        proxy_set_header X-Forwarded-Prefix /covid/;
     }
 }
 EOF


### PR DESCRIPTION
## Summary
- Updated `roles/nginx/README.md` to document the current `proxy_pass` trailing slash approach instead of outdated `rewrite` rules
- Fixed broken link in root `README.md` pointing to non-existent `docs/nginx/README.md`

## Changes
- **Path Stripping section**: Replaced rewrite rule examples with proxy_pass trailing slash implementation, added documentation for upstream blocks and X-Forwarded-Prefix header
- **Testing section**: Updated test config example to match current implementation
- **Root README**: Fixed link to point to `roles/nginx/README.md`

## Test plan
- [x] Verify documentation matches actual nginx templates in `roles/nginx/templates/`
- [x] Verify internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)