### PR TITLE
chore: lapis bump

### DIFF
--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 services:
   lapisOpen:
     container_name: {{ srsilo_current_instance_name }}-lapis
-    image: ghcr.io/genspectrum/lapis:0.6.2
+    image: ghcr.io/genspectrum/lapis:0.6.4
     restart: unless-stopped
     ports:
       - {{ srsilo_current_lapis_port }}:8080


### PR DESCRIPTION
This pull request updates the `lapisOpen` service in the `docker-compose.yml.j2` template to use a newer version of the `lapis` image.

Dependency update:

* Updated the `lapisOpen` service to use the `ghcr.io/genspectrum/lapis:0.6.4` image instead of `0.6.2` in `docker-compose.yml.j2`.