### PR TITLE
fix(srsilo): correct LAPIS-SILO image tag v0.9.5 → 0.9.5

### DIFF
--- a/roles/srsilo/templates/docker-compose-preprocessing.yml.j2
+++ b/roles/srsilo/templates/docker-compose-preprocessing.yml.j2
@@ -1,7 +1,7 @@
 services:
   siloPreprocessing:
     container_name: {{ srsilo_current_instance_name }}-preprocessing
-    image: ghcr.io/genspectrum/lapis-silo:v0.9.5
+    image: ghcr.io/genspectrum/lapis-silo:0.9.5
     command: preprocessing
     mem_limit: {{ srsilo_docker_memory_limit }}
     volumes:

--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -22,7 +22,7 @@ services:
 
   silo:
     container_name: {{ srsilo_current_instance_name }}-silo
-    image: ghcr.io/genspectrum/lapis-silo:v0.9.5
+    image: ghcr.io/genspectrum/lapis-silo:0.9.5
     mem_limit: {{ srsilo_docker_memory_limit }}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

- Fixes incorrect Docker image tag `v0.9.5` → `0.9.5` for LAPIS-SILO
- The tag `ghcr.io/genspectrum/lapis-silo:v0.9.5` does not exist (manifest unknown)
- The correct tag is `ghcr.io/genspectrum/lapis-silo:0.9.5` (no 'v' prefix)

## Root Cause

Commit e5b85b2 introduced the incorrect tag format. LAPIS-SILO uses semantic versioning without the 'v' prefix, unlike some other projects.

## Impact

- COVID LAPIS-SILO services (`wise-sarsCoV2-lapis`, `wise-sarsCoV2-silo`) failed to start
- Error: `Error response from daemon: manifest unknown`

## Files Changed

- `roles/srsilo/templates/docker-compose.yml.j2`
- `roles/srsilo/templates/docker-compose-preprocessing.yml.j2`

## Test Plan

- [x] Verified `ghcr.io/genspectrum/lapis-silo:0.9.5` exists via `docker manifest inspect`
- [x] Redeployed COVID services - pipeline currently rebuilding indexes
- [ ] Confirm services healthy after pipeline completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)