### PR TITLE
docs: document external dependencies (S3, SQL DBs)

### DIFF
--- a/docs/architecture/loculus-external-dependencies.md
+++ b/docs/architecture/loculus-external-dependencies.md
@@ -1,0 +1,49 @@
+# Loculus External Dependencies
+
+Loculus relies on external, unmanaged components that must be provisioned separately from the Ansible-managed infrastructure.
+
+## PostgreSQL Database
+
+Loculus requires two PostgreSQL databases:
+
+- **Main Database**: Stores sequence metadata, user submissions, and application data
+- **Keycloak Database**: Manages authentication and user identity data
+
+These databases are **not managed** by WisePulse's Ansible playbooks and must be set up externally.
+
+### Configuration
+
+Database credentials are stored in `group_vars/loculus/vault.yml` (encrypted).
+
+## S3-Compatible Object Storage
+
+Loculus uses S3-compatible object storage for storing sequence data files (BAM alignments, nucleotide sequences).
+
+### Configuration
+
+Configured in `group_vars/loculus/main.yml`:
+
+```yaml
+s3:
+  enabled: true
+  bucket:
+    region: eu-central
+    endpoint: https://fsn1.your-objectstorage.com/
+    bucket: wasap
+```
+
+S3 credentials (access key, secret key) are stored in `group_vars/loculus/vault.yml`.
+
+### Storage Requirements
+
+The S3 bucket stores:
+- Uploaded nucleotide alignments
+- srSILO read files
+- Preprocessing artifacts
+
+Storage size depends on the number of samples and file sizes.
+
+## See Also
+
+- [Loculus Deployment](../deployment/loculus.md) for deployment instructions
+- [Configuration Reference](../configuration/reference.md) for all configuration options

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -28,6 +28,24 @@ WisePulse consists of four main components, all managed by Ansible playbooks.
      :8080                  :8081-8084                 :3000, :9090
 ```
 
+## Data flow
+
+```
+┌──────────────┐    sr2silo     ┌──────────────┐    srSILO pipeline     ┌──────────────┐
+│   BAM files  │ ─────────────▶ │   Loculus    │ ─────────────────────▶ │ srSILO /     │
+│              │                │    (S3)      │                        │ LAPIS        │
+│              │                │ Sequence mgmt│                        │              │
+│              │                │ & storage    │                        │              │
+└──────────────┘                └──────────────┘                        └──────────────┘
+
+```
+
+1. BAM files are created by V-pipe.
+2. [sr2silo](https://github.com/cbg-ethz/sr2silo) is used to convert the files and upload them to Loculus.
+3. Loculus stores the data (using S3 under the hood to do so).
+4. the [srSILO pipeline](srsilo-pipeline.md) fetches the data from Loculus and ingest them into the short-read SILO instance (srSILO).
+5. Amplicon sequences are available in SILO/LAPIS to be queried.
+
 ## srSILO Pipeline
 
 Multi-virus genomic data pipeline **fully managed by Ansible** with:

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -73,6 +73,7 @@ In `group_vars/loculus/main.yml`:
 - Application name, host, organisms
 - URL configurations
 - Feature flags
+- S3 bucket configuration
 
 ### Secrets
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Architecture:
       - Overview: architecture/overview.md
       - srSILO Pipeline: architecture/srsilo-pipeline.md
+      - Loculus External Dependencies: architecture/loculus-external-dependencies.md
   - Deployment:
       - srSILO: deployment/srsilo.md
       - Loculus: deployment/loculus.md


### PR DESCRIPTION
I've added a new page about the S3 and postgres databases. They are vital to the architecture, but not mentioned because they are not managed by ansible.

I've added them as 'external dependencies' now, I think it's good to have some info on them in the docs!