### PR TITLE
fix: prevent nginx timeouts

### DIFF
--- a/roles/nginx/templates/sites-available/loculus.j2
+++ b/roles/nginx/templates/sites-available/loculus.j2
@@ -56,6 +56,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Forwarded-Prefix /backend/;
+        proxy_read_timeout 300s;
     }
 
     location / {
@@ -64,6 +65,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
     }
 
     listen 443 ssl http2; # managed by Certbot


### PR DESCRIPTION
When submitting from `sr2silo`, we're getting errors like this:

```
2026-02-17 23:00:37,849 - INFO - Auto-release enabled. Waiting 180 seconds before approving sequences...
2026-02-17 23:04:37,934 - ERROR - Error approving sequences: 504 Server Error: Gateway Time-out for url: https://api.db.wasap.genspectrum.org/backend/rsva/approve-processed-data
2026-02-17 23:04:37,934 - ERROR - Response: <html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx/1.24.0 (Ubuntu)</center>
</body>
</html>

2026-02-17 23:04:37,934 - ERROR - Auto-release failed: Failed to approve sequences: 504 - <html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx/1.24.0 (Ubuntu)</center>
</body>
</html>

Upload and submission failed.
```

Which indicates an nginx timeout.

I'm not entirely sure why the response takes so long, and if this is the fix, but it might be worth a try.

----

I've manually deployed this, maybe it'll help?