### PR TITLE
refactor: consolidate Ansible requirements into single file

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,0 @@
----
-- name: geerlingguy.nginx
-  version: 3.1.4

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,3 +17,5 @@ collections:
 roles:
   - src: gantsign.helm
     version: "2.13.0"
+  - name: geerlingguy.nginx
+    version: "3.1.4"


### PR DESCRIPTION
Moved geerlingguy.nginx role from ansible/requirements.yml to the root requirements.yml file. This consolidates all Ansible dependencies into a single location, simplifying installation and maintenance.

- Add geerlingguy.nginx v3.1.4 to root requirements.yml roles section
- Remove redundant ansible/requirements.yml file

🤖 Generated with [Claude Code](https://claude.com/claude-code)