### PR TITLE
fix(srSilo): do not cancel job if no new data is found

### DIFF
--- a/playbooks/srsilo/_tasks/run-single-virus-pipeline.yml
+++ b/playbooks/srsilo/_tasks/run-single-virus-pipeline.yml
@@ -90,11 +90,7 @@
       debug:
         msg:
           - "=== Pipeline Complete for {{ current_virus }} ==="
-          - "No new data available - skipping remaining phases"
-          - "This is normal and saves resources"
-    
-    - name: Skip remaining phases
-      meta: end_host
+          - "No new data available - remaining phases should be skipped"
   when: not srsilo_has_new_data
 
 - name: "PHASE 2: New data detected for {{ current_virus }} - pipeline will continue"


### PR DESCRIPTION
This removes the job where the entire job is ended if one virus has no data. This can simply be removed, because all subsequent task have the following line already:
`  when: srsilo_has_new_data`