### PR TITLE
add rsvb to duplicate list of enabled viruses

### DIFF
--- a/roles/srsilo/defaults/main.yml
+++ b/roles/srsilo/defaults/main.yml
@@ -54,6 +54,7 @@ srsilo_viruses:
 srsilo_enabled_viruses:
   - covid
   - rsva
+  - rsvb
 
 # =============================================================================
 # Derived Virus-Specific Paths (New Multi-Virus Structure)


### PR DESCRIPTION
The log messages show that WisePulse did not run the update script for rsvb:

```
Apr 23 02:00:04 Ubuntu-2404-noble-amd64-base srsilo-update[3407536]: Thursday 23 April 2026  02:00:04 +0200 (0:00:00.039)       0:00:01.576 ********
Apr 23 02:00:04 Ubuntu-2404-noble-amd64-base srsilo-update[3407536]: ok: [localhost] =>
Apr 23 02:00:04 Ubuntu-2404-noble-amd64-base srsilo-update[3407536]:   msg: 'Will process 2 virus(es): covid, rsva'
```

There is a second list of enabled viruses, where rsvb was missing