### PR TITLE
increase fetch days to 365 for all viruses

### DIFF
--- a/group_vars/srsilo/main.yml
+++ b/group_vars/srsilo/main.yml
@@ -28,17 +28,17 @@ srsilo_enabled_viruses:
 # Use this to override global defaults for specific viruses
 srsilo_virus_config:
   covid:
-    fetch_days: 180
+    fetch_days: 365
     fetch_max_reads: 1_100_000_000  # >1B reads
     chunk_size: 1_000_000         # Large chunks for production
     docker_memory_limit: 250g
   rsva:
-    fetch_days: 120
+    fetch_days: 365
     fetch_max_reads: 50_000_000   # 50M reads
     chunk_size: 500_000           # Smaller chunks
     docker_memory_limit: 50g
   rsvb:
-    fetch_days: 120
+    fetch_days: 365
     fetch_max_reads: 50_000_000     # 50M reads
     chunk_size: 500_000            # Smaller chunks
     docker_memory_limit: 50g


### PR DESCRIPTION
This increases the fetch days to 365 for all viruses. This enables us to now reprocess older data, but also has the general benefit of increasing sequence counts in our deployments, which are currently not limited by available memory