### PR TITLE
set the project name in docker-compose.yml files explicitly

### DIFF
--- a/roles/srsilo/templates/docker-compose.yml.j2
+++ b/roles/srsilo/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+name: {{ srsilo_current_instance_name }}
 services:
   lapisOpen:
     container_name: {{ srsilo_current_instance_name }}-lapis


### PR DESCRIPTION
this will allow restarts to work even when the compose file has been moved